### PR TITLE
Fix some bugs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "kubernetes_manifest" "host" {
         tlsSecret = {
           name = var.tls_secret_name
         }
-      } : tomap()
+      } : tomap({})
     )
   }
 }
@@ -53,7 +53,7 @@ resource "kubernetes_manifest" "mapping" {
       },
       var.tls_origination_enable ? {
         tls = var.name
-      } : {},
+      } : tomap({}),
       var.mapping_spec,
     )
   }

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "kubernetes_manifest" "host" {
         tlsSecret = {
           name = var.tls_secret_name
         }
-      } : {}
+      } : tomap()
     )
   }
 }
@@ -61,6 +61,7 @@ resource "kubernetes_manifest" "mapping" {
 
 resource "kubernetes_manifest" "tls_origination" {
   provider = kubernetes-alpha
+  count    = var.tls_origination_enable ? 1 : 0
 
   manifest = {
     apiVersion = "getambassador.io/v2"

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "namespace" {
 
 variable "ambassador_id" {
   description = "Ambassador ID to create CRDs for"
-  default     = "default"
+  default     = ["default"]
 }
 
 variable "hostname" {

--- a/variables.tf
+++ b/variables.tf
@@ -72,7 +72,7 @@ variable "insecure_request_policy" {
   description = "Request policy of insecure requests"
   default = {
     action         = "Redirect"
-    additionalPort = "8080"
+    additionalPort = 8080
   }
 }
 


### PR DESCRIPTION
- Fix error "The true and false result expressions must have consistent
types. The given expressions are object and object, respectively." for
mapping TLS settings
- Fix default port number for insecure redirection to an integer
- Fix TLSContext for TLS origination not being conditionally created
