### PR TITLE
Add `tlsSecret` to `Host`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,9 +23,16 @@ resource "kubernetes_manifest" "host" {
         tlsContext = {
           name = kubernetes_manifest.tlscontext[0].manifest.metadata.name
         }
+        tlsSecret = {
+          name = var.tls_secret_name
+        }
       } : tomap({}),
       var.host_spec,
     )
+  }
+
+  field_manager {
+    force_conflicts = true
   }
 }
 
@@ -54,6 +61,10 @@ resource "kubernetes_manifest" "mapping" {
       var.mapping_spec,
     )
   }
+
+  field_manager {
+    force_conflicts = true
+  }
 }
 
 resource "kubernetes_manifest" "tlscontext" {
@@ -79,6 +90,10 @@ resource "kubernetes_manifest" "tlscontext" {
       var.tlscontext_spec,
     )
   }
+
+  field_manager {
+    force_conflicts = true
+  }
 }
 
 resource "kubernetes_manifest" "tls_origination" {
@@ -102,5 +117,9 @@ resource "kubernetes_manifest" "tls_origination" {
       },
       var.tls_origination_spec,
     )
+  }
+
+  field_manager {
+    force_conflicts = true
   }
 }


### PR DESCRIPTION
Must be added alongside `tlsContext`. For compatibility with Emissary
Ingress 2.x. See https://www.getambassador.io/docs/emissary/2.1/topics/running/host-crd/#tlscontext-links-to-a-tlscontext-for-additional-configuration

> `tlsContext` specifies a `TLSContext` to use for additional TLS information. Note that you must still define `tlsSecret` for TLS termination to happen. It is an error to supply both `tlsContext` and `tls`.
